### PR TITLE
Upgrading Flare Flutter version to 1.5.15

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -182,14 +182,14 @@ packages:
       name: flare_dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.5"
+    version: "2.0.0"
   flare_flutter:
     dependency: "direct main"
     description:
       name: flare_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.7"
+    version: "1.5.15"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   intl_translation: ^0.17.7
 
   # UI
-  flare_flutter: 1.5.7
+  flare_flutter: 1.5.15
 
 
 


### PR DESCRIPTION
As observed, it was required to upgrade to the latest version of Flare Flutter to override compilation issues with the older version of the dependency.

After upgrading the dependency, the application now compiles and runs.

Fixes #69 