### PR TITLE
Feature: Occurrences Widget Implementation

### DIFF
--- a/lib/presentation/ui/occurrences_time_widget.dart
+++ b/lib/presentation/ui/occurrences_time_widget.dart
@@ -49,7 +49,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
       type: MaterialType.transparency,
       child: new Container (
                 decoration: new BoxDecoration(
-                  color: Colors.grey,
+                  color: Colors.white,
                   boxShadow: [new BoxShadow(
                   color: Colors.black,
                   blurRadius: 20.0,
@@ -67,31 +67,30 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                 new Container(
                                   child: new Text(
                                     "Início",
-                                    overflow: TextOverflow.clip,
-                                    style: DefaultTextStyle.of(context).style.apply(
-                                        fontSizeFactor: 0.5,
-                                        decoration: TextDecoration.none,
-                                        color: Colors.grey
-                                    )
+                                    style: TextStyle(
+                                      color: Colors.grey,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 25,
+                                    ),
                                   ),
                                 ),
                                 new Container(
                                   child: new Text(
                                     getFormattedDate(this._startTime, FORMAT_DATE_HOUR),
-                                    style: DefaultTextStyle.of(context).style.apply(
-                                        fontSizeFactor: 0.5,
-                                        decoration: TextDecoration.none,
-                                        color: Colors.lightGreen
+                                    style: TextStyle(
+                                      color: Colors.lightGreen[700],
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 30,
                                     ),
                                   ),
                                 ),
                                 new Container(
                                   child: new Text(
                                     getFormattedDate(this._startTime, FORMAT_DATE_DAY),
-                                    style: DefaultTextStyle.of(context).style.apply(
-                                        fontSizeFactor: 0.5,
-                                        decoration: TextDecoration.none,
-                                        color: Colors.lightGreen
+                                    style: TextStyle(
+                                      color: Colors.lightGreen[700],
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 30,
                                     ),
                                   ),
                                 ),
@@ -103,30 +102,31 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                 new Container(
                                   child: new Text(
                                     "Fim",
-                                    style: DefaultTextStyle.of(context).style.apply(
-                                        fontSizeFactor: 0.5,
-                                        decoration: TextDecoration.none,
-                                        color: Colors.grey
+                                    style: TextStyle(
+                                      color: Colors.grey,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 25,
                                     ),
                                   ),
                                 ),
                                 new Container(
                                   child: new Text(
                                     getFormattedDate(this._endTime, FORMAT_DATE_HOUR),
-                                    style: DefaultTextStyle.of(context).style.apply(
-                                        fontSizeFactor: 0.5,
-                                        decoration: TextDecoration.none,
-                                        color: Colors.lightGreen
+                                    style: TextStyle(
+                                      color: Colors.lightGreen[700],
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 30,
                                     ),
                                   ),
                                 ),
                                 new Container(
                                   child: new Text(
                                     getFormattedDate(this._endTime, FORMAT_DATE_DAY),
-                                    style: DefaultTextStyle.of(context).style.apply(
-                                        fontSizeFactor: 0.5,
-                                        decoration: TextDecoration.none,
-                                        color: Colors.lightGreen),
+                                    style: TextStyle(
+                                      color: Colors.lightGreen[700],
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 30,
+                                    ),
                                   ),
                                 ),
                               ],
@@ -140,10 +140,10 @@ class OccurrencesTimeWidget extends StatelessWidget {
                               child: new Text(
                                 "Ultima atualização : " + getFormattedDate(this._lastUpdated, FORMAT_DATE_FULL),
                                 textAlign: TextAlign.center,
-                                style: DefaultTextStyle.of(context).style.apply(
-                                    fontSizeFactor: 0.3,
-                                    decoration: TextDecoration.none,
-                                    color: Colors.white),
+                                style: TextStyle(
+                                  color: Colors.grey[700],
+                                  fontSize: 20,
+                                ),
                               ),
                             ),
                           ],

--- a/lib/presentation/ui/occurrences_time_widget.dart
+++ b/lib/presentation/ui/occurrences_time_widget.dart
@@ -21,7 +21,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
     if (date != null) {
       switch(typeOfFormat) {
         case 'full': {
-          formatter = new DateFormat('HH-mm-yyyy-MM-dd');
+          formatter = new DateFormat('HH:mm yyyy-MM-dd');
           break;
         }
         case 'day': {
@@ -29,7 +29,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
           break;
         }
         case 'hour': {
-          formatter = new DateFormat('HH-mm');
+          formatter = new DateFormat('HH:mm');
           break;
         }
         default: {

--- a/lib/presentation/ui/occurrences_time_widget.dart
+++ b/lib/presentation/ui/occurrences_time_widget.dart
@@ -10,13 +10,36 @@ class OccurrencesTimeWidget extends StatelessWidget {
   const OccurrencesTimeWidget(this._startTime, this._endTime, this._lastUpdated);
 
   static const String EMPTY_DATE_STRING = "--";
+  static const String FORMAT_DATE_DAY = "day";
+  static const String FORMAT_DATE_HOUR = "hour";
+  static const String FORMAT_DATE_FULL = "full";
 
-  String getFormattedDate(DateTime date, bool shouldUseOnlyTime) {
+  String getFormattedDate(DateTime date, String typeOfFormat) {
     String formattedDate = EMPTY_DATE_STRING;
+    DateFormat formatter;
+
     if (date != null) {
-      DateFormat formatter = shouldUseOnlyTime ? new DateFormat('HH-mm') : new DateFormat('yyyy-MM-dd');
+      switch(typeOfFormat) {
+        case 'full': {
+          formatter = new DateFormat('HH-mm-yyyy-MM-dd');
+          break;
+        }
+        case 'day': {
+          formatter = new DateFormat('yyyy-MM-dd');
+          break;
+        }
+        case 'hour': {
+          formatter = new DateFormat('HH-mm');
+          break;
+        }
+        default: {
+
+        }
+      }
+
       formattedDate = formatter.format(date);
     }
+
     return formattedDate;
   }
 
@@ -51,7 +74,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  getFormattedDate(this._startTime, true),
+                                  getFormattedDate(this._startTime, FORMAT_DATE_HOUR),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -60,7 +83,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  getFormattedDate(this._startTime, false),
+                                  getFormattedDate(this._startTime, FORMAT_DATE_DAY),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -83,7 +106,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  getFormattedDate(this._endTime, true),
+                                  getFormattedDate(this._endTime, FORMAT_DATE_HOUR),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -92,7 +115,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  getFormattedDate(this._endTime, false),
+                                  getFormattedDate(this._endTime, FORMAT_DATE_DAY),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -107,14 +130,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: <Widget>[
                             new Text(
-                        this._lastUpdated != null ?
-                              "Ultima atualização : " +
-                                  this._lastUpdated.hour.toString() +
-                                  ":" +
-                                  this._lastUpdated.minute.toString() + " " +
-                                  this._lastUpdated.day.toString() + "-" +
-                                  this._lastUpdated.month.toString() + "-" +
-                                  this._lastUpdated.year.toString() : "--",
+                              "Ultima atualização : " + getFormattedDate(this._lastUpdated, FORMAT_DATE_FULL),
                               overflow: TextOverflow.clip,
                               textAlign: TextAlign.center,
                               style: DefaultTextStyle.of(context).style.apply(

--- a/lib/presentation/ui/occurrences_time_widget.dart
+++ b/lib/presentation/ui/occurrences_time_widget.dart
@@ -64,64 +64,71 @@ class OccurrencesTimeWidget extends StatelessWidget {
                             new Column(
                               mainAxisSize: MainAxisSize.min,
                               children: <Widget>[
-                                new Text(
-                                  "Início",
-                                  overflow: TextOverflow.clip,
-                                  style: DefaultTextStyle.of(context).style.apply(
-                                      fontSizeFactor: 0.5,
-                                      decoration: TextDecoration.none,
-                                      color: Colors.grey
+                                new Container(
+                                  child: new Text(
+                                    "Início",
+                                    overflow: TextOverflow.clip,
+                                    style: DefaultTextStyle.of(context).style.apply(
+                                        fontSizeFactor: 0.5,
+                                        decoration: TextDecoration.none,
+                                        color: Colors.grey
+                                    )
                                   ),
                                 ),
-                                new Text(
-                                  getFormattedDate(this._startTime, FORMAT_DATE_HOUR),
-                                  overflow: TextOverflow.clip,
-                                  style: DefaultTextStyle.of(context).style.apply(
-                                      fontSizeFactor: 0.5,
-                                      decoration: TextDecoration.none,
-                                      color: Colors.lightGreen
+                                new Container(
+                                  child: new Text(
+                                    getFormattedDate(this._startTime, FORMAT_DATE_HOUR),
+                                    style: DefaultTextStyle.of(context).style.apply(
+                                        fontSizeFactor: 0.5,
+                                        decoration: TextDecoration.none,
+                                        color: Colors.lightGreen
+                                    ),
                                   ),
                                 ),
-                                new Text(
-                                  getFormattedDate(this._startTime, FORMAT_DATE_DAY),
-                                  overflow: TextOverflow.clip,
-                                  style: DefaultTextStyle.of(context).style.apply(
-                                      fontSizeFactor: 0.5,
-                                      decoration: TextDecoration.none,
-                                      color: Colors.lightGreen
+                                new Container(
+                                  child: new Text(
+                                    getFormattedDate(this._startTime, FORMAT_DATE_DAY),
+                                    style: DefaultTextStyle.of(context).style.apply(
+                                        fontSizeFactor: 0.5,
+                                        decoration: TextDecoration.none,
+                                        color: Colors.lightGreen
+                                    ),
                                   ),
-                                )
+                                ),
                               ],
                             ),
                             new Column(
                               mainAxisSize: MainAxisSize.min,
                               children: <Widget>[
-                                new Text(
-                                  "Fim",
-                                  overflow: TextOverflow.clip,
-                                  style: DefaultTextStyle.of(context).style.apply(
-                                      fontSizeFactor: 0.5,
-                                      decoration: TextDecoration.none,
-                                      color: Colors.grey
+                                new Container(
+                                  child: new Text(
+                                    "Fim",
+                                    style: DefaultTextStyle.of(context).style.apply(
+                                        fontSizeFactor: 0.5,
+                                        decoration: TextDecoration.none,
+                                        color: Colors.grey
+                                    ),
                                   ),
                                 ),
-                                new Text(
-                                  getFormattedDate(this._endTime, FORMAT_DATE_HOUR),
-                                  overflow: TextOverflow.clip,
-                                  style: DefaultTextStyle.of(context).style.apply(
-                                      fontSizeFactor: 0.5,
-                                      decoration: TextDecoration.none,
-                                      color: Colors.lightGreen
+                                new Container(
+                                  child: new Text(
+                                    getFormattedDate(this._endTime, FORMAT_DATE_HOUR),
+                                    style: DefaultTextStyle.of(context).style.apply(
+                                        fontSizeFactor: 0.5,
+                                        decoration: TextDecoration.none,
+                                        color: Colors.lightGreen
+                                    ),
                                   ),
                                 ),
-                                new Text(
-                                  getFormattedDate(this._endTime, FORMAT_DATE_DAY),
-                                  overflow: TextOverflow.clip,
-                                  style: DefaultTextStyle.of(context).style.apply(
-                                      fontSizeFactor: 0.5,
-                                      decoration: TextDecoration.none,
-                                      color: Colors.lightGreen),
-                                )
+                                new Container(
+                                  child: new Text(
+                                    getFormattedDate(this._endTime, FORMAT_DATE_DAY),
+                                    style: DefaultTextStyle.of(context).style.apply(
+                                        fontSizeFactor: 0.5,
+                                        decoration: TextDecoration.none,
+                                        color: Colors.lightGreen),
+                                  ),
+                                ),
                               ],
                             ),
                           ],
@@ -129,14 +136,15 @@ class OccurrencesTimeWidget extends StatelessWidget {
                         new Row(
                           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                           children: <Widget>[
-                            new Text(
-                              "Ultima atualização : " + getFormattedDate(this._lastUpdated, FORMAT_DATE_FULL),
-                              overflow: TextOverflow.clip,
-                              textAlign: TextAlign.center,
-                              style: DefaultTextStyle.of(context).style.apply(
-                                  fontSizeFactor: 0.3,
-                                  decoration: TextDecoration.none,
-                                  color: Colors.white),
+                            new Container(
+                              child: new Text(
+                                "Ultima atualização : " + getFormattedDate(this._lastUpdated, FORMAT_DATE_FULL),
+                                textAlign: TextAlign.center,
+                                style: DefaultTextStyle.of(context).style.apply(
+                                    fontSizeFactor: 0.3,
+                                    decoration: TextDecoration.none,
+                                    color: Colors.white),
+                              ),
                             ),
                           ],
                         )

--- a/lib/presentation/ui/occurrences_time_widget.dart
+++ b/lib/presentation/ui/occurrences_time_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 class OccurrencesTimeWidget extends StatelessWidget {
 
@@ -13,9 +14,8 @@ class OccurrencesTimeWidget extends StatelessWidget {
   String getFormattedDate(DateTime date, bool shouldUseOnlyTime) {
     String formattedDate = EMPTY_DATE_STRING;
     if (date != null) {
-      formattedDate = shouldUseOnlyTime ?
-      (date.hour.toString() + ":" + date.minute.toString()) :
-      (date.day.toString() + "-" + date.month.toString() + "-" + this._startTime.year.toString());
+      DateFormat formatter = shouldUseOnlyTime ? new DateFormat('HH-mm') : new DateFormat('yyyy-MM-dd');
+      formattedDate = formatter.format(date);
     }
     return formattedDate;
   }
@@ -51,7 +51,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  getFormattedDate(this._startTime, false),
+                                  getFormattedDate(this._startTime, true),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -60,7 +60,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  getFormattedDate(this._startTime, true),
+                                  getFormattedDate(this._startTime, false),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -83,7 +83,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  getFormattedDate(this._endTime, false),
+                                  getFormattedDate(this._endTime, true),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -92,7 +92,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  getFormattedDate(this._endTime, true),
+                                  getFormattedDate(this._endTime, false),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,

--- a/lib/presentation/ui/occurrences_time_widget.dart
+++ b/lib/presentation/ui/occurrences_time_widget.dart
@@ -8,6 +8,18 @@ class OccurrencesTimeWidget extends StatelessWidget {
 
   const OccurrencesTimeWidget(this._startTime, this._endTime, this._lastUpdated);
 
+  static const String EMPTY_DATE_STRING = "--";
+
+  String getFormattedDate(DateTime date, bool shouldUseOnlyTime) {
+    String formattedDate = EMPTY_DATE_STRING;
+    if (date != null) {
+      formattedDate = shouldUseOnlyTime ?
+      (date.hour.toString() + ":" + date.minute.toString()) :
+      (date.day.toString() + "-" + date.month.toString() + "-" + this._startTime.year.toString());
+    }
+    return formattedDate;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Material(
@@ -39,7 +51,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  this._startTime != null ? this._startTime.hour.toString() + ":" + this._startTime.minute.toString() : "--",
+                                  getFormattedDate(this._startTime, false),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -48,7 +60,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  this._startTime != null ? this._startTime.day.toString() + "-" + this._startTime.month.toString() + "-" + this._startTime.year.toString() : "--",
+                                  getFormattedDate(this._startTime, true),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -71,7 +83,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  this._endTime != null ? this._endTime.hour.toString() + ":" + this._endTime.minute.toString() : "--",
+                                  getFormattedDate(this._endTime, false),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,
@@ -80,7 +92,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                                   ),
                                 ),
                                 new Text(
-                                  this._endTime != null ? this._endTime.day.toString() + "-" + this._endTime.month.toString() + "-" + this._endTime.year.toString() : "--",
+                                  getFormattedDate(this._endTime, true),
                                   overflow: TextOverflow.clip,
                                   style: DefaultTextStyle.of(context).style.apply(
                                       fontSizeFactor: 0.5,

--- a/lib/presentation/ui/occurrences_time_widget.dart
+++ b/lib/presentation/ui/occurrences_time_widget.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+class OccurrencesTimeWidget extends StatelessWidget {
+
+  final DateTime _startTime;
+  final DateTime _endTime;
+  final DateTime _lastUpdated;
+
+  const OccurrencesTimeWidget(this._startTime, this._endTime, this._lastUpdated);
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      type: MaterialType.transparency,
+      child: new Container (
+                decoration: new BoxDecoration(
+                  color: Colors.grey,
+                  boxShadow: [new BoxShadow(
+                  color: Colors.black,
+                  blurRadius: 20.0,
+                  )],
+                ),
+                child:
+                    new Column(
+                      children: <Widget>[
+                        new Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: <Widget>[
+                            new Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                new Text(
+                                  "Início",
+                                  overflow: TextOverflow.clip,
+                                  style: DefaultTextStyle.of(context).style.apply(
+                                      fontSizeFactor: 0.5,
+                                      decoration: TextDecoration.none,
+                                      color: Colors.grey
+                                  ),
+                                ),
+                                new Text(
+                                  this._startTime != null ? this._startTime.hour.toString() + ":" + this._startTime.minute.toString() : "--",
+                                  overflow: TextOverflow.clip,
+                                  style: DefaultTextStyle.of(context).style.apply(
+                                      fontSizeFactor: 0.5,
+                                      decoration: TextDecoration.none,
+                                      color: Colors.lightGreen
+                                  ),
+                                ),
+                                new Text(
+                                  this._startTime != null ? this._startTime.day.toString() + "-" + this._startTime.month.toString() + "-" + this._startTime.year.toString() : "--",
+                                  overflow: TextOverflow.clip,
+                                  style: DefaultTextStyle.of(context).style.apply(
+                                      fontSizeFactor: 0.5,
+                                      decoration: TextDecoration.none,
+                                      color: Colors.lightGreen
+                                  ),
+                                )
+                              ],
+                            ),
+                            new Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                new Text(
+                                  "Fim",
+                                  overflow: TextOverflow.clip,
+                                  style: DefaultTextStyle.of(context).style.apply(
+                                      fontSizeFactor: 0.5,
+                                      decoration: TextDecoration.none,
+                                      color: Colors.grey
+                                  ),
+                                ),
+                                new Text(
+                                  this._endTime != null ? this._endTime.hour.toString() + ":" + this._endTime.minute.toString() : "--",
+                                  overflow: TextOverflow.clip,
+                                  style: DefaultTextStyle.of(context).style.apply(
+                                      fontSizeFactor: 0.5,
+                                      decoration: TextDecoration.none,
+                                      color: Colors.lightGreen
+                                  ),
+                                ),
+                                new Text(
+                                  this._endTime != null ? this._endTime.day.toString() + "-" + this._endTime.month.toString() + "-" + this._endTime.year.toString() : "--",
+                                  overflow: TextOverflow.clip,
+                                  style: DefaultTextStyle.of(context).style.apply(
+                                      fontSizeFactor: 0.5,
+                                      decoration: TextDecoration.none,
+                                      color: Colors.lightGreen),
+                                )
+                              ],
+                            ),
+                          ],
+                        ),
+                        new Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                          children: <Widget>[
+                            new Text(
+                        this._lastUpdated != null ?
+                              "Ultima atualização : " +
+                                  this._lastUpdated.hour.toString() +
+                                  ":" +
+                                  this._lastUpdated.minute.toString() + " " +
+                                  this._lastUpdated.day.toString() + "-" +
+                                  this._lastUpdated.month.toString() + "-" +
+                                  this._lastUpdated.year.toString() : "--",
+                              overflow: TextOverflow.clip,
+                              textAlign: TextAlign.center,
+                              style: DefaultTextStyle.of(context).style.apply(
+                                  fontSizeFactor: 0.3,
+                                  decoration: TextDecoration.none,
+                                  color: Colors.grey),
+                            ),
+                          ],
+                        )
+                      ],
+                    )
+                ),
+    );
+
+  }
+
+}

--- a/lib/presentation/ui/occurrences_time_widget.dart
+++ b/lib/presentation/ui/occurrences_time_widget.dart
@@ -108,7 +108,7 @@ class OccurrencesTimeWidget extends StatelessWidget {
                               style: DefaultTextStyle.of(context).style.apply(
                                   fontSizeFactor: 0.3,
                                   decoration: TextDecoration.none,
-                                  color: Colors.grey),
+                                  color: Colors.white),
                             ),
                           ],
                         )


### PR DESCRIPTION
Adding the implementation for occurrences widget. This is a stateless widget which accepts three DateTime objects (which may be null). We display the content using a container with a column containing two rows

If any of the DateTime objects is null, a "--" will be displayed (see check in line 42 as an example).
There could be a better way to hide this if logic, but it becomes a bit more complicated as rendering widgets does not allow if/ternary logic. 

Resolves #22 .

![app](https://user-images.githubusercontent.com/23402988/66707414-b153d400-ed48-11e9-8857-f7c939c87ac0.jpg)

If there is a requirement for comments, please let me know.

