### PR TITLE
Tests counties endpoint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 
   #core
   rxdart: ^0.20.0
-  shared_preferences: ^0.4.3
+  shared_preferences: ^0.5.3+5
   stream_disposable: ^0.0.1
 
   # Network

--- a/test/data/remote/endpoints/county_endpoints_test.dart
+++ b/test/data/remote/endpoints/county_endpoints_test.dart
@@ -1,0 +1,125 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+import 'package:vost/constants.dart';
+import 'package:vost/data/remote/endpoints/county_endpoints.dart';
+
+import '../../../utils/dioadapter/_base_dio_adapter.dart';
+
+void main() {
+  group("CountyEndpoints getCounties()", () {
+    test('200 Response Valid Json Test', () async {
+      final mockDio =
+          BaseDioAdapter.success(path: pathCounties, response: okResponseValid)
+              .getMockedDioClient();
+      final countyEndpoints = CountyEndpoints(mockDio);
+
+      final counties = await countyEndpoints.getCounties();
+
+      expect(counties.statusCode, 200);
+      expect(counties.data, jsonDecode(okResponseValid));
+    });
+
+    test('200 Response Invalid Json Test', () async {
+      final mockDio = BaseDioAdapter.success(
+              path: pathCounties, response: okResponseInvalid)
+          .getMockedDioClient();
+      final countyEndpoints = CountyEndpoints(mockDio);
+
+      dynamic error;
+      try {
+        await countyEndpoints.getCounties();
+      } catch (e) {
+        error = e;
+      }
+      expect(error, TypeMatcher<DioError>());
+      //check if the underlying of DioError error is FormatException
+      expect(error.error, TypeMatcher<FormatException>());
+    });
+
+    test('500 Response Test', () async {
+      final mockDio =
+          BaseDioAdapter.failure(path: pathCounties,statusCode: 500,response: okResponseValid).getMockedDioClient();
+      final countyEndpoints = CountyEndpoints(mockDio);
+
+      dynamic error;
+      try {
+        await countyEndpoints.getCounties();
+      } catch (e) {
+        error = e;
+      }
+      expect(error, TypeMatcher<DioError>());
+      expect(error.response.statusCode,500);
+    });
+  });
+}
+
+final okResponseValid = """
+{
+    "links": {
+        "first": "https://api.vost.pt/v1/counties?page=1",
+        "last": "https://api.vost.pt/v1/counties?page=308",
+        "next": "https://api.vost.pt/v1/counties?page=2"
+    },
+    "data": [
+        {
+            "type": "counties",
+            "id": "270",
+            "attributes": {
+                "code": "181600",
+                "name": "SÃO PEDRO DO SUL",
+                "created_at": "2019-07-02 13:31:05",
+                "updated_at": "2019-07-02 13:31:05"
+            },
+            "relationships": {
+                "district": {
+                    "data": null
+                }
+            },
+            "links": {
+                "self": "https://api.vost.pt/v1/counties/270"
+            }
+        }
+    ],
+    "meta": {
+        "items": 1,
+        "total": 308
+    }
+}
+""";
+
+final okResponseInvalid = """
+{ <<INVALID CHARACTERS>>
+    "links": {
+        "first": "https://api.vost.pt/v1/counties?page=1",
+        "last": "https://api.vost.pt/v1/counties?page=308",
+        "next": "https://api.vost.pt/v1/counties?page=2"
+    },
+    "data": [
+        {
+            "type": "counties",
+            "id": "270",
+            "attributes": {
+                "code": "181600",
+                "name": "SÃO PEDRO DO SUL",
+                "created_at": "2019-07-02 13:31:05",
+                "updated_at": "2019-07-02 13:31:05"
+            },
+            "relationships": {
+                "district": {
+                    "data": null
+                }
+            },
+            "links": {
+                "self": "https://api.vost.pt/v1/counties/270"
+            }
+        }
+    ],
+    "meta": {
+        "items": 1,
+        "total": 308
+    }
+}
+""";

--- a/test/data/remote/services/county_service_test.dart
+++ b/test/data/remote/services/county_service_test.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'package:vost/constants.dart';
+import 'package:vost/data/remote/endpoints/county_endpoints.dart';
+import 'package:vost/data/remote/models/response/base_list_response.dart';
+import 'package:vost/data/remote/services/county_service.dart';
+
+import '../../../utils/dioadapter/_base_dio_adapter.dart';
+
+class MockCountyEndpoint extends Mock implements CountyEndpoints {}
+
+void main() {
+  group("CountyService getCounties()", () {
+    test('200 Response Valid Json Test', () async {
+      final mockEndpoint = MockCountyEndpoint();
+      final baseListResponse = BaseListResponse.fromJson((okResponseValid));
+      final mockResponse = Response(statusCode: 200, data: (okResponseValid));
+      when(mockEndpoint.getCounties())
+          .thenAnswer((_) => Future.value(mockResponse));
+      final service = CountyService(mockEndpoint);
+
+      final counties = service.getCounties();
+
+      verify(mockEndpoint.getCounties()).called(1);
+      await expectLater(counties, emits(baseListResponse));
+    });
+
+    test('Faield Request', () async {
+      final mockEndpoint = MockCountyEndpoint();
+      when(mockEndpoint.getCounties()).thenThrow(DioError(message: "error"));
+      final service = CountyService(mockEndpoint);
+
+      dynamic error;
+      try {
+        final counties = service.getCounties();
+      } catch (e) {
+        error = e;
+      }
+      expect(error, TypeMatcher<DioError>());
+      expect(error.message,"error");
+    });
+  });
+}
+
+final okResponseValid = """
+{
+    "links": {
+        "first": "https://api.vost.pt/v1/counties?page=1",
+        "last": "https://api.vost.pt/v1/counties?page=308",
+        "next": "https://api.vost.pt/v1/counties?page=2"
+    },
+    "data": [
+        {
+            "type": "counties",
+            "id": "270",
+            "attributes": {
+                "code": "181600",
+                "name": "SÃO PEDRO DO SUL",
+                "created_at": "2019-07-02 13:31:05",
+                "updated_at": "2019-07-02 13:31:05"
+            },
+            "relationships": {
+                "district": null
+            },
+            "links": {
+                "self": "https://api.vost.pt/v1/counties/270"
+            }
+        }
+    ],
+    "meta": {
+        "items": 1,
+        "total": 308
+    }
+}
+""";

--- a/test/utils/dioadapter/_base_dio_adapter.dart
+++ b/test/utils/dioadapter/_base_dio_adapter.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:vost/constants.dart';
+
+class BaseDioAdapter extends HttpClientAdapter {
+  final DefaultHttpClientAdapter _defaultHttpClientAdapter =
+      DefaultHttpClientAdapter();
+
+  final String path;
+  final String response;
+  final int statusCode;
+
+  BaseDioAdapter(this.path, this.response, this.statusCode);
+
+  BaseDioAdapter.success({this.path, this.response}) : statusCode = 200;
+
+  BaseDioAdapter.failure({this.path, this.response, this.statusCode = 500});
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>> requestStream, Future cancelFuture) async {
+    Uri uri = options.uri;
+    if (uri.host == mockHost) {
+      if(uri.path == "/$path"){
+        return ResponseBody.fromString(
+          response,
+          statusCode,
+          DioHttpHeaders.fromMap({
+            HttpHeaders.contentTypeHeader: ContentType.json,
+          }),
+        );
+      }else{
+        return ResponseBody.fromString("", 404, DioHttpHeaders());
+      }
+    }
+    return _defaultHttpClientAdapter.fetch(
+        options, requestStream, cancelFuture);
+  }
+
+  Dio getMockedDioClient(){
+    final dio = Dio();
+    dio.options.baseUrl = mockBase;
+    dio.httpClientAdapter = this;
+    return dio;
+  }
+}


### PR DESCRIPTION
Added a base class for mock Dio adapter so testing XEndpoints classes should be easier.

```dart
final mockDio = BaseDioAdapter.failure(
          path: pathCounties,
          response: okResponseValid
      ).getMockedDioClient();
final countyEndpoints = CountyEndpoints(mockDio);
```

Closes #37  